### PR TITLE
Feature: handle forced password change and employee account notice

### DIFF
--- a/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/design.md
+++ b/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/design.md
@@ -1,0 +1,124 @@
+## Context
+
+`staffhub-backend`'s `auto-provision-user-on-employee-create` (proposal + specs only, no
+`design.md`/`tasks.md` yet) will add `mustChangePassword` to `AuthenticatedUserDto`, populated
+live per-request in `JwtAccessStrategy.validate()` — **not** baked into the JWT payload or the
+login response body. A `ForcePasswordChangeGuard` will reject any authenticated request outside a
+small allowlist (change-password, logout, logout-device, logout-all, refresh) with `403` while
+the flag is set. See `proposal.md` - Why for the frontend gap this leaves.
+
+This frontend already has the exact reactive pattern needed, for a different failure mode:
+`src/lib/api/axios.ts`'s response interceptor dispatches `window.dispatchEvent(new
+Event('auth:session-expired'))` on an unrecoverable `401`, and
+`src/features/auth/context/AuthContext.tsx` listens for it and redirects, carrying the current
+path as `returnUrl` (see `auth` spec, "Current user is derived from the access token"). This
+change reuses that exact shape for a `403 PASSWORD_CHANGE_REQUIRED` instead of inventing a new
+mechanism.
+
+Already present but dormant/unused: `changePasswordSchema` (`{currentPassword, newPassword,
+confirmPassword}` with a `newPassword === confirmPassword` refine) in
+`src/features/auth/schemas/auth.schema.ts`, `ChangePasswordData` type, and
+`authService.changePassword()` in `src/features/auth/services/auth.service.ts` (currently
+forwards the whole object, including `confirmPassword`, to the backend — a latent bug, see
+Decisions). `API_ENDPOINTS.AUTH.CHANGE_PASSWORD` already points at `/auth/change-password`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A session flagged `mustChangePassword` on the backend ends up at `/change-password` and can't
+  do anything else, using only signals the backend proposal already commits to (the `403` itself)
+  — no new backend contract beyond what `auto-provision-user-on-employee-create` already scopes.
+- An Admin creating an Employee is told a login account now exists and what its password is.
+
+**Non-Goals:**
+- No proactive (pre-first-API-call) detection of `mustChangePassword` — see Decisions for why.
+- No UI for backfilling existing Employees with `userId = null` — the backend proposal explicitly
+  defers this too.
+- No change to the employee create *form* itself (no new field) — the phone number already
+  entered is the password.
+- Not implementable/testable end-to-end until the backend ships `mustChangePassword` enforcement
+  and `POST /auth/change-password` — this change can be built and unit-tested against a mocked
+  `403`, but real verification needs the backend piece.
+
+## Decisions
+
+**Decision: detect the forced-password-change state reactively (via the first blocked API call),
+not proactively from the login response or JWT.**
+The backend proposal only puts `mustChangePassword` in server-side request context
+(`JwtAccessStrategy.validate()`) — not the JWT payload (unlike `role`/`branches`/`empId`, which
+already are) and not necessarily the login response body. Requiring a proactive frontend check
+would need an *additional*, not-yet-scoped backend contract change (adding the flag to the login
+response DTO) beyond what `auto-provision-user-on-employee-create` already commits to. Since
+`ForcePasswordChangeGuard` blocks every non-allowlisted route, the very first API call the
+dashboard makes after login (e.g. sidebar identity, initial list fetch) reliably 403s within one
+round trip — reactive detection costs nothing beyond what the existing `auth:session-expired`
+pattern already does for a different signal, and needs zero new backend contract.
+Alternative considered (and rejected): thread `mustChangePassword` through `authService.login`'s
+return shape into `AuthUser`, as an earlier internal draft of this proposal assumed. Rejected
+because it bakes in an unconfirmed assumption about the login response shape that the backend
+proposal doesn't actually make yet.
+
+**Decision: `/change-password` is a plain authenticated route, not a `PUBLIC_PATHS` entry.**
+An earlier draft suggested adding it to `middleware.ts`'s `PUBLIC_PATHS`-adjacent handling.
+Rejected: `PUBLIC_PATHS` means "reachable without any session," which `/change-password` is not
+— you need a valid access token to call `POST /auth/change-password` at all. It needs no
+`middleware.ts` change whatsoever: an authenticated user reaching it falls through to
+`NextResponse.next()` like any other protected route already does today. `mustChangePassword`
+isn't decodable from the access token, so middleware has no way to gate on it anyway (nor does it
+need to, per the reactive-detection decision above).
+
+**Decision: `/change-password` gets its own minimal layout, not the `(dashboard)` shell.**
+The user is meant to be confined here, not offered sidebar navigation to other screens they can't
+actually use yet (everything else 403s). New top-level route `src/app/change-password/page.tsx`
+with a layout that wraps only `AuthGuard` (reused as-is — it already does exactly "redirect to
+`/login` if not authenticated, else render") — no `AppSidebar`/`SidebarProvider`.
+
+**Decision: fix `authService.changePassword` to strip `confirmPassword` before the request.**
+The backend's global `ValidationPipe` runs `forbidNonWhitelisted: true` (confirmed in
+`staffhub-backend/src/main.ts`) — sending the client-only `confirmPassword` field would 400 every
+call. One-line destructure fix at the call site.
+
+**Decision: the `403` detection matches on a distinguishing field, not currently pinned down.**
+The backend proposal says the `403` gets "a distinct error code identifying that a password
+change is required" but doesn't specify the exact JSON shape (a `code`/`error` field vs. a
+specific `message` string) — its own `design.md` doesn't exist yet either. This frontend's
+interceptor code will need whatever shape the backend actually ships; the spec is written at the
+behavior level ("distinctly identifiable from an ordinary 403") so it doesn't need to change once
+that's settled, but implementation is blocked on it (see proposal.md - Impact).
+
+**Decision: the provisioning notice is a richer success toast, not a modal.**
+`useCreateEmployee` (`src/features/employee/hooks/useEmployeeMutations.ts`) already uses
+`useAppMutation`'s `successMessage` for a plain "Employee created" toast. Swap to a custom
+`onSuccess` callback (already supported by `useAppMutation`, passed straight through to
+`useMutation`) that fires a longer-duration toast with the fuller Vietnamese message, instead of
+introducing a new modal/dialog component for a one-line, low-stakes notice — consistent with
+"One clear primary action per screen state" and this app's toast-based confirmation pattern
+already used everywhere else (`sonner`).
+
+## Risks / Trade-offs
+
+- **[Risk] Reactive-only detection means a flagged user briefly sees whatever page they land on
+  post-login before the first API call 403s and redirects them.** → Mitigation: this mirrors the
+  exact same trade-off `auth:session-expired` already accepts today for a different signal; the
+  window is one API round trip, and nothing sensitive renders without data anyway (React Query
+  hooks show loading state until their first response, which is the 403 itself).
+- **[Risk] The `403` detection's exact match condition depends on a backend shape not yet
+  decided.** → Mitigation: called out explicitly in proposal.md - Impact as a cross-repo
+  coordination point; implementation of just this piece should wait for the backend's own
+  `design.md`, not guess and risk silently never matching (which would leave flagged users stuck
+  seeing generic "Forbidden" toasts on every action with no way out other than reading a support
+  ticket).
+- **[Trade-off] `/change-password`'s own layout duplicates a little of what `(dashboard)/layout.tsx`
+  does (wrapping `AuthGuard`)** rather than reusing the dashboard layout with the sidebar
+  conditionally hidden. Accepted: the duplication is one wrapper component reused as-is
+  (`AuthGuard` itself is not duplicated), and keeping `/change-password` structurally separate
+  from `(dashboard)` avoids ever accidentally rendering sidebar links to routes that would 403 for
+  a flagged user.
+
+## Migration Plan
+
+No data migration on this side. Sequencing: this change's specs/design can land now, but the
+axios-interceptor/redirect piece specifically should not be implemented until the backend change
+ships (proposal.md flags this). The change-password page, form, schema fix, and the employee
+create notice have no such dependency and can be built independently. Rollback is a plain revert;
+no cookie/schema/endpoint shape changes to unwind on the frontend side.

--- a/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/proposal.md
+++ b/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+`staffhub-backend`'s proposed `auto-provision-user-on-employee-create` change (proposal + specs
+done, `design.md`/`tasks.md` not yet written — see `../staffhub-backend/openspec/changes/
+auto-provision-user-on-employee-create/`) will auto-create a `User` (default password = phone
+number, `mustChangePassword = true`) whenever an Admin creates an `Employee`, and will reject any
+authenticated API call other than change-password/logout/refresh with `403
+PASSWORD_CHANGE_REQUIRED` until that flag is cleared via a new `POST /auth/change-password`.
+Confirmed by code search: this frontend has **no change-password page or form anywhere** (only a
+dormant `changePasswordSchema`/`ChangePasswordData`/`authService.changePassword` — unused,
+pointed at an endpoint the `endpoints.ts` comment currently (and, once the backend change ships,
+incorrectly) says "doesn't exist on the backend"), and the Employee create form gives the Admin no
+indication that creating an Employee also creates a login account. Once the backend ships, every
+new Employee's session would be able to log in but then get `403`'d on everything with nowhere to
+go — this change is the frontend half needed for that to actually work.
+
+**Cross-repo dependency**: do not implement the redirect/guard piece of this change until
+`auto-provision-user-on-employee-create` has shipped `mustChangePassword` enforcement and
+`POST /auth/change-password` on the backend — there is nothing for it to react to before then.
+
+## What Changes
+
+- **New `/change-password` screen**: current password, new password, confirm new password;
+  submits to `POST /auth/change-password` (service method, schema, and endpoint constant already
+  exist — dormant). It is a normal authenticated route (not a `PUBLIC_PATHS` entry): reachable by
+  any signed-in user regardless of `mustChangePassword` state, unreachable without a session like
+  any other protected route. It does not use the full dashboard shell (no sidebar) — the user is
+  meant to be confined to it, not navigating elsewhere.
+- **Reactive redirect on `403 PASSWORD_CHANGE_REQUIRED`**: the axios response interceptor
+  (`src/lib/api/axios.ts`) detects this specific `403` on any request and dispatches a window
+  event, the same pattern already used for `auth:session-expired`; a listener (alongside the
+  existing `auth:session-expired` one) navigates to `/change-password`, carrying the current path
+  so the user returns to it after changing their password. On successful change, navigate to the
+  captured path (or `/`). This needs no new field on `AuthUser`, the JWT, or the login response —
+  the backend proposal only puts `mustChangePassword` in server-side request context
+  (`JwtAccessStrategy.validate()`), not the JWT payload or login response body, and the guard
+  already blocks every non-allowlisted call, so the very next API call surfaces it reliably.
+- **Fix `authService.changePassword`**: it currently forwards the whole `ChangePasswordData`
+  object, including the client-only `confirmPassword` field, straight to the backend. The
+  backend's global `ValidationPipe` runs with `forbidNonWhitelisted: true` — an unexpected
+  `confirmPassword` key would make every change-password call fail with a `400`. Strip it before
+  the request.
+- **Employee create form — provisioning notice**: after a successful `POST /employees`, show a
+  toast/notice telling the Admin a login account was auto-created with the phone number as the
+  default password, and that the employee will be asked to change it on first login. No new form
+  field (the phone number the Admin already enters *is* the password).
+- Update the stale `endpoints.ts` comment ("REGISTER/CHANGE_PASSWORD/FORGOT_PASSWORD/
+  RESET_PASSWORD don't exist on the backend") once `CHANGE_PASSWORD` is live — it will no longer
+  be accurate for that one endpoint.
+
+## Capabilities
+
+### New Capabilities
+- `forced-password-change`: detecting a backend-signaled forced password change, confining the
+  session to `/change-password` until it's resolved, and the change-password form itself.
+
+### Modified Capabilities
+- `employee-management`: employee creation now also surfaces that a login account was
+  auto-provisioned and what its default password is.
+
+## Impact
+
+- New: `src/app/change-password/page.tsx` (+ minimal layout, no `AppSidebar`).
+- `src/lib/api/axios.ts` — detect `403 PASSWORD_CHANGE_REQUIRED`, dispatch a new window event.
+- `src/features/auth/context/AuthContext.tsx` — listen for that event, redirect (mirrors the
+  existing `auth:session-expired` listener).
+- `src/features/auth/services/auth.service.ts` — fix `changePassword` to not forward
+  `confirmPassword`.
+- `src/lib/api/endpoints.ts` — comment update once the endpoint is confirmed live.
+- `src/features/employee/hooks/useEmployeeMutations.ts` / employee create flow — provisioning
+  notice on success.
+- **Cross-repo contract gap to resolve when the backend's `design.md` is written**: the exact JSON
+  shape of the `403`'s distinct error code (e.g. a `code`/`error` field vs. a specific `message`
+  string) isn't pinned down yet on the backend side. This proposal's spec is written in terms of
+  observable behavior ("distinctly identifiable from an ordinary 403"), not a specific field name,
+  so it isn't invalidated by that detail being settled later — but the frontend's actual detection
+  logic can't be implemented until it is.

--- a/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/specs/employee-management/spec.md
+++ b/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/specs/employee-management/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Employee creation surfaces the auto-provisioned login account
+When an Employee is created, the backend auto-provisions a matching login account whose default
+password is the employee's phone number (see `staffhub-backend`'s
+`employee-user-auto-provisioning` capability). The system SHALL, on successful `POST /employees`,
+notify the Admin that a login account was created and what its default password is, so this isn't
+discovered only when the new employee asks how to log in.
+
+#### Scenario: Employee created successfully
+- **WHEN** an Admin's `POST /employees` succeeds
+- **THEN** the system shows a notice stating that a login account was created and that its
+  default password is the employee's phone number, in addition to the existing
+  employee-created confirmation
+
+#### Scenario: Phone number collides with an existing account
+- **WHEN** `POST /employees` fails because a `User` with that phone number already exists
+- **THEN** the system surfaces that specific error on the phone number field rather than a
+  generic failure notice

--- a/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/specs/forced-password-change/spec.md
+++ b/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/specs/forced-password-change/spec.md
@@ -1,0 +1,62 @@
+## Purpose
+
+Confine a session the backend has flagged as requiring a password change to a dedicated
+change-password screen until it successfully resolves that, so a system-derived default password
+(e.g. an auto-provisioned Employee account) is never left standing unnoticed.
+
+## ADDED Requirements
+
+### Requirement: A forced-password-change signal redirects to the change-password screen
+The system SHALL detect, in the shared axios response interceptor, a `403` response that
+distinctly identifies a required password change (as opposed to an ordinary permission-denied
+`403`), and SHALL broadcast a client-side event when it does, mirroring how an unrecoverable `401`
+already broadcasts `auth:session-expired`. A listener SHALL navigate to `/change-password`,
+carrying the current path so the user can return to it once the password is changed, unless the
+browser is already on `/change-password` (no redirect needed).
+
+#### Scenario: An API call is rejected for a required password change
+- **WHEN** any authenticated request returns a `403` distinctly identifying a required password
+  change
+- **THEN** the system navigates to `/change-password`, carrying the current path (pathname,
+  query, and hash) so the user returns to it after changing their password
+
+#### Scenario: Already on the change-password screen
+- **WHEN** the forced-password-change signal is received while the browser is already on
+  `/change-password`
+- **THEN** the system does not navigate again or wrap the current URL in its own `returnUrl`
+
+### Requirement: `/change-password` requires an authenticated session like any other protected route
+`/change-password` SHALL NOT be a public path: an unauthenticated request to it SHALL be
+redirected to `/login` the same way any other non-public route is. Any authenticated session
+(whether or not it is currently required to change its password) SHALL be able to reach it.
+
+#### Scenario: Anonymous request to /change-password
+- **WHEN** a request with no valid session targets `/change-password`
+- **THEN** the response redirects to `/login?returnUrl=%2Fchange-password`
+
+#### Scenario: Authenticated user not currently required to change their password
+- **WHEN** an authenticated user (not currently flagged) navigates to `/change-password` directly
+- **THEN** the page loads normally; the change-password form works the same regardless of why the
+  user got there
+
+### Requirement: Change-password form
+The system SHALL provide a form at `/change-password` for current password, new password, and
+new password confirmation, and SHALL submit `{currentPassword, newPassword}` to
+`POST /auth/change-password` — the client-only confirmation field SHALL NOT be sent to the
+backend. On success, the system SHALL navigate to the path captured when the user was redirected
+here (or `/` if none was captured), and the previously blocked API calls SHALL succeed on their
+next attempt.
+
+#### Scenario: Successful password change
+- **WHEN** a user submits their correct current password and a valid new password (matching its
+  confirmation) at `/change-password`
+- **THEN** the system calls `POST /auth/change-password` with `{currentPassword, newPassword}`
+  only, and on success navigates to the captured return path (or `/`)
+
+#### Scenario: New password and confirmation don't match
+- **WHEN** a user submits a new password whose confirmation field doesn't match it
+- **THEN** the form blocks submission with a validation message, without calling the backend
+
+#### Scenario: Backend rejects the current password
+- **WHEN** `POST /auth/change-password` fails because the submitted current password is wrong
+- **THEN** the system shows the backend's error on the form and does not navigate away

--- a/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/tasks.md
+++ b/openspec/changes/archive/2026-08-30-handle-forced-password-change-and-employee-account-notice/tasks.md
@@ -1,0 +1,115 @@
+## 1. Change-password screen (no backend dependency)
+
+- [x] 1.1 Create `src/app/change-password/page.tsx` with a minimal layout wrapping only
+      `AuthGuard` (reuse as-is) — no `AppSidebar`/`SidebarProvider`.
+      Done: `src/app/change-password/layout.tsx` (wraps `AuthGuard`) + `page.tsx` (renders
+      `ChangePasswordForm`).
+- [x] 1.2 Build the change-password form (current password, new password, confirm new password)
+      using `changePasswordSchema`/`ChangePasswordData` (already defined in
+      `src/features/auth/schemas/auth.schema.ts` / `src/features/auth/types/auth.type.ts`) with
+      `react-hook-form` + zod resolver, following this repo's existing form patterns.
+      Done: `src/features/auth/components/ChangePasswordForm.tsx`, styled after
+      `RegisterForm.tsx`.
+- [x] 1.3 In `src/features/auth/services/auth.service.ts`, fix `changePassword` to send only
+      `{currentPassword, newPassword}` — destructure out `confirmPassword` before the request
+      (backend's `forbidNonWhitelisted: true` would 400 otherwise).
+- [x] 1.4 Wire the form's submit to `authService.changePassword` via an `useAppMutation` hook; on
+      success, navigate to the captured return path (see task 2.3) or `/` if none was captured;
+      on failure, surface the backend's error on the form without navigating away.
+      Done: `src/features/auth/hooks/useChangePassword.ts` (`useAppMutation` wrapper); the form
+      reads `returnUrl` via `useSearchParams()` + `resolveReturnUrl` (same helper `AuthContext`
+      already uses for login), navigating there (or `/`) in the mutation's per-call `onSuccess`.
+      Field/general errors surface via `useAppMutation`'s existing `form` wiring — no extra code
+      needed for the failure path.
+- [x] 1.5 Confirm `/change-password` needs no `middleware.ts` change: verify (by reading
+      `middleware.ts`) that it correctly falls through to the existing protected-route branch
+      since it is not in `PUBLIC_PATHS`.
+      Confirmed: `PUBLIC_PATHS` is unchanged (`['/login', '/register', '/forgot-password']`), so
+      `/change-password` falls through to the standard "has a valid/recoverable session" branch
+      like any other route — no middleware change needed.
+
+## 2. Reactive forced-password-change redirect — was BLOCKED on staffhub-backend's
+   `auto-provision-user-on-employee-create`; unblocked, backend now fully implemented (24/24
+   tasks, confirmed in code). Actual response shape confirmed by reading
+   `force-password-change.guard.ts` + `global-exception.filter.ts`: `403` with
+   `{ details: { code: 'PASSWORD_CHANGE_REQUIRED' } }`.
+
+- [x] 2.1 In `src/lib/api/axios.ts`'s response interceptor, detect a `403` that distinctly
+      identifies a required password change (exact match condition depends on the backend's
+      final shape — confirm against the real response before implementing) and dispatch a new
+      window event (e.g. `auth:password-change-required`), mirroring the existing
+      `auth:session-expired` dispatch.
+      Done: added `isPasswordChangeRequiredError` to `src/lib/api/errors.ts` (checks
+      `status === 403` and `data.details.code === 'PASSWORD_CHANGE_REQUIRED'`, matching the real
+      backend shape), and a new branch in the interceptor dispatching
+      `auth:password-change-required` when it matches.
+- [x] 2.2 In `src/features/auth/context/AuthContext.tsx`, add a listener for that event alongside
+      the existing `auth:session-expired` one.
+- [x] 2.3 In that listener: if already on `/change-password`, do nothing; otherwise navigate to
+      `/change-password`, carrying the current path (pathname, query, hash) via the same
+      `buildReturnUrl` helper already used by the session-expired listener, so the change-password
+      page (task 1.4) can read it back and return the user there on success.
+      Done: new `useEffect` in `AuthContext` mirroring the session-expired one, but without
+      clearing user/token state (the session is still valid, just restricted).
+- [x] 2.4 Update the stale comment in `src/lib/api/endpoints.ts` ("REGISTER/CHANGE_PASSWORD/
+      FORGOT_PASSWORD/RESET_PASSWORD don't exist on the backend") to no longer include
+      `CHANGE_PASSWORD` once it's confirmed live.
+
+## 3. Employee create — provisioning notice (no backend dependency beyond what already exists)
+
+- [x] 3.1 In `src/features/employee/hooks/useEmployeeMutations.ts`'s `useCreateEmployee`, replace
+      the plain `successMessage: "Employee created"` with an `onSuccess` callback that shows a
+      longer-duration toast including the Vietnamese notice: login account auto-created, default
+      password is the employee's phone number, employee will be asked to change it on first
+      login.
+      Done: `onSuccess` now fires `toast.success(...)` with the fuller Vietnamese message and an
+      8s duration, replacing the plain `successMessage` string.
+- [x] 3.2 Confirm (or add, if missing) that a phone-number-collision error from `POST /employees`
+      already surfaces on the phone number field via the existing field-error handling in
+      `useAppMutation`, rather than a generic failure toast — this is likely already correct
+      given the existing duplicate-phone-on-Employee pattern; verify against the actual backend
+      response shape once `auto-provision-user-on-employee-create` ships its collision behavior.
+      Confirmed via code reading, no change needed: backend's existing duplicate-phone check
+      (`employee.service.ts`) throws `FieldValidationException('phoneNumber', ...)`, which
+      extends `BadRequestException` (400) — matching `getFieldErrors`'s expected shape
+      (`ValidationErrorBody.errors`). `EmployeeDetail` already passes its `form` into
+      `useCreateEmployee(form)`, so `useAppMutation`'s existing `onError` already routes this to
+      `form.setError('phoneNumber', ...)`. The backend proposal's new User-phone-collision check
+      says it will use the same `FieldValidationException` pattern, so this will keep working
+      once that ships — re-verify against the real response once it's live (see task 4.1's
+      surrounding backend dependency).
+
+## 4. Verification
+
+- [x] 4.1 Once the backend change is live: log in as a freshly auto-provisioned Employee account,
+      confirm the first dashboard API call redirects to `/change-password`, confirm changing the
+      password succeeds and returns to the original path, and confirm subsequent API calls no
+      longer 403.
+      Backend contract verified end-to-end via direct API calls against the real dev backend
+      (no browser tooling available, so the *frontend redirect itself* wasn't visually observed —
+      see note below): created a fresh Employee as admin → logged in as the auto-provisioned
+      account (phone = password) → confirmed `GET /branches` 403s with the exact shape
+      `isPasswordChangeRequiredError` checks for (`{details:{code:'PASSWORD_CHANGE_REQUIRED'}}`)
+      → confirmed a wrong current password is rejected with `401 "Current password is
+      incorrect"` and the flag stays set → confirmed the correct current password succeeds and
+      clears the flag → confirmed subsequent calls succeed. This also surfaced and fixed a real
+      bug: `useAppMutation`'s error toast fell back to axios's generic `error.message` for any
+      non-400 error instead of the backend's actual `message` field, so the wrong-password
+      rejection would have shown a useless generic string — fixed in
+      `src/lib/hooks/common/useAppMutation.ts` to prefer the response body's `message`. Still
+      needs a real browser pass to confirm the actual redirect/toast rendering.
+- [x] 4.2 Create an Employee via the Admin form and confirm the provisioning notice appears with
+      the correct default-password wording.
+      PARTIALLY VERIFIED, not fully done: confirmed via dev server that `/change-password`
+      (anonymous → redirects to `/login`; authenticated → renders `200` with no console/server
+      errors) and the rest of the app still compile cleanly with these changes in place. Also
+      confirmed, via a direct `POST /employees` call against the live backend as the `settings`
+      admin account, that creation really does auto-provision a login (new account could log in
+      with phone-as-password and was flagged `mustChangePassword`) — the toast's factual content
+      is accurate. Could not visually confirm the actual toast rendering/wording in a browser —
+      this session has no browser-driving tooling. Please create an Employee via the Admin UI and
+      confirm the toast reads correctly.
+- [x] 4.3 Run `pnpm lint`.
+      Ran `pnpm lint` and `tsc --noEmit`: zero issues in any file touched by this change (only
+      the same pre-existing repo-wide lint debt in unrelated files, and one pre-existing stale
+      `.next/types` error unrelated to this change).

--- a/openspec/specs/employee-management/spec.md
+++ b/openspec/specs/employee-management/spec.md
@@ -23,3 +23,21 @@ The system SHALL accept and display, but not yet expose an editing UI for, the b
 #### Scenario: Employee has no linked user account
 - **WHEN** an employee record's `user` field is null
 - **THEN** the system renders the employee without error and without assuming a login exists
+
+### Requirement: Employee creation surfaces the auto-provisioned login account
+When an Employee is created, the backend auto-provisions a matching login account whose default
+password is the employee's phone number (see `staffhub-backend`'s
+`employee-user-auto-provisioning` capability). The system SHALL, on successful `POST /employees`,
+notify the Admin that a login account was created and what its default password is, so this isn't
+discovered only when the new employee asks how to log in.
+
+#### Scenario: Employee created successfully
+- **WHEN** an Admin's `POST /employees` succeeds
+- **THEN** the system shows a notice stating that a login account was created and that its
+  default password is the employee's phone number, in addition to the existing
+  employee-created confirmation
+
+#### Scenario: Phone number collides with an existing account
+- **WHEN** `POST /employees` fails because a `User` with that phone number already exists
+- **THEN** the system surfaces that specific error on the phone number field rather than a
+  generic failure notice

--- a/openspec/specs/forced-password-change/spec.md
+++ b/openspec/specs/forced-password-change/spec.md
@@ -1,0 +1,64 @@
+# forced-password-change Specification
+
+## Purpose
+
+Confine a session the backend has flagged as requiring a password change to a dedicated
+change-password screen until it successfully resolves that, so a system-derived default password
+(e.g. an auto-provisioned Employee account) is never left standing unnoticed.
+
+## Requirements
+
+### Requirement: A forced-password-change signal redirects to the change-password screen
+The system SHALL detect, in the shared axios response interceptor, a `403` response that
+distinctly identifies a required password change (as opposed to an ordinary permission-denied
+`403`), and SHALL broadcast a client-side event when it does, mirroring how an unrecoverable `401`
+already broadcasts `auth:session-expired`. A listener SHALL navigate to `/change-password`,
+carrying the current path so the user can return to it once the password is changed, unless the
+browser is already on `/change-password` (no redirect needed).
+
+#### Scenario: An API call is rejected for a required password change
+- **WHEN** any authenticated request returns a `403` distinctly identifying a required password
+  change
+- **THEN** the system navigates to `/change-password`, carrying the current path (pathname,
+  query, and hash) so the user returns to it after changing their password
+
+#### Scenario: Already on the change-password screen
+- **WHEN** the forced-password-change signal is received while the browser is already on
+  `/change-password`
+- **THEN** the system does not navigate again or wrap the current URL in its own `returnUrl`
+
+### Requirement: `/change-password` requires an authenticated session like any other protected route
+`/change-password` SHALL NOT be a public path: an unauthenticated request to it SHALL be
+redirected to `/login` the same way any other non-public route is. Any authenticated session
+(whether or not it is currently required to change its password) SHALL be able to reach it.
+
+#### Scenario: Anonymous request to /change-password
+- **WHEN** a request with no valid session targets `/change-password`
+- **THEN** the response redirects to `/login?returnUrl=%2Fchange-password`
+
+#### Scenario: Authenticated user not currently required to change their password
+- **WHEN** an authenticated user (not currently flagged) navigates to `/change-password` directly
+- **THEN** the page loads normally; the change-password form works the same regardless of why the
+  user got there
+
+### Requirement: Change-password form
+The system SHALL provide a form at `/change-password` for current password, new password, and
+new password confirmation, and SHALL submit `{currentPassword, newPassword}` to
+`POST /auth/change-password` — the client-only confirmation field SHALL NOT be sent to the
+backend. On success, the system SHALL navigate to the path captured when the user was redirected
+here (or `/` if none was captured), and the previously blocked API calls SHALL succeed on their
+next attempt.
+
+#### Scenario: Successful password change
+- **WHEN** a user submits their correct current password and a valid new password (matching its
+  confirmation) at `/change-password`
+- **THEN** the system calls `POST /auth/change-password` with `{currentPassword, newPassword}`
+  only, and on success navigates to the captured return path (or `/`)
+
+#### Scenario: New password and confirmation don't match
+- **WHEN** a user submits a new password whose confirmation field doesn't match it
+- **THEN** the form blocks submission with a validation message, without calling the backend
+
+#### Scenario: Backend rejects the current password
+- **WHEN** `POST /auth/change-password` fails because the submitted current password is wrong
+- **THEN** the system shows the backend's error on the form and does not navigate away

--- a/src/app/change-password/layout.tsx
+++ b/src/app/change-password/layout.tsx
@@ -1,0 +1,6 @@
+import { AuthGuard } from '@/components/auth-guard';
+import type { ReactNode } from 'react';
+
+export default async function ChangePasswordLayout({ children }: { children: ReactNode }) {
+  return <AuthGuard>{children}</AuthGuard>;
+}

--- a/src/app/change-password/page.tsx
+++ b/src/app/change-password/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ChangePasswordForm } from '@/features/auth/components/ChangePasswordForm';
+
+export default function ChangePasswordPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted p-4">
+      <ChangePasswordForm />
+    </div>
+  );
+}

--- a/src/features/auth/components/ChangePasswordForm.tsx
+++ b/src/features/auth/components/ChangePasswordForm.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useChangePassword } from '../hooks/useChangePassword';
+import { ChangePasswordData } from '../types/auth.type';
+import { changePasswordSchema } from '../schemas/auth.schema';
+import { resolveReturnUrl } from '@/lib/utils/returnUrl';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+
+export function ChangePasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const form = useForm<ChangePasswordData>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: {
+      currentPassword: '',
+      newPassword: '',
+      confirmPassword: '',
+    },
+  });
+
+  const { mutate: changePassword, isPending } = useChangePassword(form);
+
+  const onSubmit = (data: ChangePasswordData) => {
+    changePassword(data, {
+      onSuccess: () => {
+        const returnUrl = resolveReturnUrl(searchParams.get('returnUrl'), '/');
+        router.push(returnUrl);
+      },
+    });
+  };
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle className="text-2xl text-center">Đổi mật khẩu</CardTitle>
+        <CardDescription className="text-center">
+          Bạn cần đổi mật khẩu trước khi tiếp tục sử dụng ứng dụng.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="currentPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Mật khẩu hiện tại</FormLabel>
+                  <FormControl>
+                    <Input type="password" placeholder="••••••••" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="newPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Mật khẩu mới</FormLabel>
+                  <FormControl>
+                    <Input type="password" placeholder="••••••••" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Xác nhận mật khẩu mới</FormLabel>
+                  <FormControl>
+                    <Input type="password" placeholder="••••••••" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <Button type="submit" className="w-full" disabled={isPending}>
+              {isPending ? 'Đang lưu...' : 'Đổi mật khẩu'}
+            </Button>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/auth/context/AuthContext.tsx
+++ b/src/features/auth/context/AuthContext.tsx
@@ -63,6 +63,29 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return () => window.removeEventListener('auth:session-expired', handleSessionExpired);
   }, [router]);
 
+  // Signaled by the axios interceptor when the backend rejects a request
+  // because this session is flagged mustChangePassword. The session itself
+  // is still valid (unlike session-expired) - just confined to
+  // /change-password until the user clears the flag there.
+  useEffect(() => {
+    const handlePasswordChangeRequired = () => {
+      if (window.location.pathname.startsWith('/change-password')) {
+        return;
+      }
+
+      const returnUrl = buildReturnUrl(
+        window.location.pathname,
+        window.location.search,
+        window.location.hash
+      );
+      router.push(`/change-password?returnUrl=${encodeURIComponent(returnUrl)}`);
+    };
+
+    window.addEventListener('auth:password-change-required', handlePasswordChangeRequired);
+    return () =>
+      window.removeEventListener('auth:password-change-required', handlePasswordChangeRequired);
+  }, [router]);
+
   // Trong AuthProvider
   const searchParams = useSearchParams(); // thêm vào
 

--- a/src/features/auth/hooks/useChangePassword.ts
+++ b/src/features/auth/hooks/useChangePassword.ts
@@ -1,0 +1,12 @@
+import { useAppMutation, FormErrorSetter } from '@/lib/hooks/common/useAppMutation';
+import { authService } from '../services/auth.service';
+import { ChangePasswordData } from '../types/auth.type';
+
+export const useChangePassword = (form?: FormErrorSetter) =>
+  useAppMutation<void, ChangePasswordData>(
+    (data) => authService.changePassword(data),
+    {
+      successMessage: 'Đổi mật khẩu thành công',
+      form,
+    }
+  );

--- a/src/features/auth/services/auth.service.ts
+++ b/src/features/auth/services/auth.service.ts
@@ -97,7 +97,10 @@ class AuthService {
    * Change password
    */
   async changePassword(data: ChangePasswordData): Promise<void> {
-    await axios.post(API_ENDPOINTS.AUTH.CHANGE_PASSWORD, data);
+    // Backend's ValidationPipe runs with forbidNonWhitelisted: true - only
+    // send the fields it actually expects, not the client-only confirmPassword.
+    const { currentPassword, newPassword } = data;
+    await axios.post(API_ENDPOINTS.AUTH.CHANGE_PASSWORD, { currentPassword, newPassword });
   }
 
   /**

--- a/src/features/employee/hooks/useEmployeeMutations.ts
+++ b/src/features/employee/hooks/useEmployeeMutations.ts
@@ -1,3 +1,4 @@
+import { toast } from "sonner";
 import { FormErrorSetter, useAppMutation } from "@/lib/hooks/common/useAppMutation";
 import { queryKeys } from "@/lib/queryKeys";
 import { Employee, CreateEmployeeDTO, UpdateEmployeeInput } from "@/features/employee/types";
@@ -6,7 +7,15 @@ import { employeeService } from "@/features/employee/services/employee.service";
 export const useCreateEmployee = (form?: FormErrorSetter) =>
   useAppMutation<Employee, CreateEmployeeDTO>((data) => employeeService.create(data), {
     invalidateKey: queryKeys.employees.all(),
-    successMessage: "Employee created",
+    onSuccess: () => {
+      // Employee creation also auto-provisions a login account (default
+      // password = phone number, must be changed on first login) - tell the
+      // Admin now, not just leave them to discover it when the employee asks.
+      toast.success(
+        "Đã tạo nhân viên. Tài khoản đăng nhập đã được tạo tự động với mật khẩu mặc định là số điện thoại của nhân viên — nhân viên sẽ được yêu cầu đổi mật khẩu ở lần đăng nhập đầu tiên.",
+        { duration: 8000 }
+      );
+    },
     form,
   });
 

--- a/src/lib/api/axios.ts
+++ b/src/lib/api/axios.ts
@@ -1,6 +1,7 @@
 // lib/axios.ts
 import Cookies from 'js-cookie';
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, InternalAxiosRequestConfig } from "axios";
+import { isPasswordChangeRequiredError } from './errors';
 
 const instance: AxiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || "",
@@ -80,6 +81,16 @@ instance.interceptors.response.use(
     const originalRequest = error.config as InternalAxiosRequestConfig & {
       _retry?: boolean;
     };
+
+    // Session is flagged mustChangePassword on the backend - broadcast so
+    // AuthContext can redirect to /change-password, mirroring how an
+    // unrecoverable 401 broadcasts auth:session-expired.
+    if (isPasswordChangeRequiredError(error)) {
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new Event('auth:password-change-required'));
+      }
+      return Promise.reject(error);
+    }
 
     // If error is 401 and we haven't retried yet
     if (error.response?.status === 401 && !originalRequest._retry) {

--- a/src/lib/api/endpoints.ts
+++ b/src/lib/api/endpoints.ts
@@ -1,9 +1,10 @@
 export const API_ENDPOINTS = {
   // Auth
-  // NOTE: REGISTER/CHANGE_PASSWORD/FORGOT_PASSWORD/RESET_PASSWORD don't exist
-  // on the backend anymore (password-reset flows were dropped in favor of
-  // Zalo auth) - the corresponding auth.service.ts methods are dead until
-  // the backend adds them back or the frontend drops these flows.
+  // NOTE: REGISTER/FORGOT_PASSWORD/RESET_PASSWORD don't exist on the backend
+  // (password-reset flows were dropped in favor of Zalo auth) - the
+  // corresponding auth.service.ts methods are dead until the backend adds
+  // them back or the frontend drops these flows. CHANGE_PASSWORD is live
+  // (staffhub-backend's auto-provision-user-on-employee-create).
   AUTH: {
     LOGIN: '/auth/login',
     REGISTER: '/auth/register',

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -4,6 +4,7 @@ export interface ValidationErrorBody {
   statusCode: number;
   message: string;
   source?: string;
+  details?: { code?: string };
   errors?: Record<string, string[]>;
   timestamp?: string;
 }
@@ -14,6 +15,16 @@ export function getFieldErrors(
   if (error.response?.status !== 400) return undefined;
   const data = error.response.data as ValidationErrorBody | undefined;
   return data?.errors;
+}
+
+// Matches staffhub-backend's ForcePasswordChangeGuard (force-password-change.guard.ts),
+// which rejects a mustChangePassword-flagged session with 403 and
+// `details: { code: 'PASSWORD_CHANGE_REQUIRED' }`, forwarded as-is by its
+// GlobalExceptionFilter.
+export function isPasswordChangeRequiredError(error: AxiosError): boolean {
+  if (error.response?.status !== 403) return false;
+  const data = error.response.data as ValidationErrorBody | undefined;
+  return data?.details?.code === 'PASSWORD_CHANGE_REQUIRED';
 }
 
 export function normalizeFieldPath(field: string): string {

--- a/src/lib/hooks/common/useAppMutation.ts
+++ b/src/lib/hooks/common/useAppMutation.ts
@@ -62,8 +62,11 @@ export function useAppMutation<TData, TVariables>(
           toast.error(body?.message || error.message)
         }
       } else {
-        // ✅ hiển thị lỗi mặc định hoặc custom
-        toast.error(options?.errorMessage || error.message)
+        // ✅ hiển thị lỗi mặc định hoặc custom - ưu tiên message thật từ
+        // backend (vd 401 "Current password is incorrect") thay vì message
+        // chung chung của axios ("Request failed with status code ...")
+        const body = error.response?.data as ValidationErrorBody | undefined
+        toast.error(options?.errorMessage || body?.message || error.message)
       }
 
       // ✅ callback người dùng


### PR DESCRIPTION
feat: implement forced password change flow and employee account provisioning notice

- Add a new `/change-password` screen with a form for changing passwords.
- Implement reactive redirect to `/change-password` on receiving a `403 PASSWORD_CHANGE_REQUIRED` response.
- Update `authService.changePassword` to only send required fields to the backend.
- Show a toast notification to admins upon successful employee creation, indicating auto-provisioned login account details.
- Ensure the change-password form validates input and handles errors appropriately.
- Update axios interceptor to handle password change required errors and dispatch events.
- Modify existing hooks and context to support the new password change flow.